### PR TITLE
Add initial Next.js app structure

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css'
+import type { ReactNode } from 'react'
+
+export const metadata = {
+  title: 'Meu Site',
+  description: 'Página inicial',
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="pt-BR">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Bem-vindo ao meu site!</h1>
+}


### PR DESCRIPTION
## Summary
- scaffold `app/` directory for Next.js
- add a basic homepage
- include minimal global styles and layout

## Testing
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852ec8254f48323860094594c7017b2